### PR TITLE
feat: add 26.75 to the scale lengths

### DIFF
--- a/src/model/consts.ts
+++ b/src/model/consts.ts
@@ -180,6 +180,7 @@ export const SCALE_LENGTHS = [
 	26,
 	26.25,
 	26.5,
+	26.75,
 	27,
 	27.5,
 	28,


### PR DESCRIPTION
## Description

Adds 26.75 scale length in order to support guitars like the reverend descent (baritone with 26.75 scale length).

https://reverendguitars.com/guitars/descent-ra/